### PR TITLE
Support bun partially

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,9 @@ For pnpm:
 ```bash
 pnpm dlx vp-update
 ```
+
+For bun:
+
+```bash
+bunx vp-update
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,9 @@ const cli = cac("vp-update");
 
 cli
   .command("[dir]", "Update VuePress project")
-  .usage("pnpm dlx vp-update [dir] / npx vp-update [dir]")
+  .usage(
+    "pnpm dlx vp-update [dir] / npx vp-update [dir] / bunx vp-update [dir]"
+  )
   .example("docs")
   .action(async (targetDir = "") => {
     console.log("Upgrading current project...");
@@ -59,6 +61,8 @@ cli
         ? `yarn upgrade`
         : packageManager === "yarn"
         ? `yarn up`
+        : packageManager === "bun"
+        ? `bun update`
         : `npm update`;
 
     execaCommandSync(updateCommand, { stdout: "inherit" });
@@ -68,7 +72,8 @@ cli
 
 cli.help(() => [
   {
-    title: "pnpm dlx vp-update [dir] / npx vp-update [dir]",
+    title:
+      "pnpm dlx vp-update [dir] / npx vp-update [dir] / bunx vp-update [dir]",
     body: "Update VuePress project in [dir]",
   },
 ]);

--- a/src/utils/packageManager.ts
+++ b/src/utils/packageManager.ts
@@ -3,13 +3,14 @@ import { dirname, resolve } from "node:path";
 
 import { execaCommandSync } from "execa";
 
-export type PackageManager = "npm" | "yarn" | "yarn1" | "pnpm";
+export type PackageManager = "npm" | "yarn" | "yarn1" | "pnpm" | "bun";
 
 const globalCache = new Map<string, boolean>();
 const localCache = new Map<string, PackageManager>();
 
 const NPM_LOCK = "package-lock.json";
 const YARN_LOCK = "yarn.lock";
+const BUN_LOCK = "bun.lockb";
 const PNPM_LOCK = "pnpm-lock.yaml";
 
 const isInstalled = (packageManager: PackageManager): boolean => {
@@ -74,6 +75,12 @@ export const getTypeofLockFile = (
     return packageManager;
   }
 
+  if (existsSync(resolve(cwd, BUN_LOCK))) {
+    localCache.set(key, "bun");
+
+    return "bun";
+  }
+
   if (existsSync(resolve(cwd, NPM_LOCK))) {
     localCache.set(key, "npm");
 
@@ -104,6 +111,12 @@ export const getTypeofLockFile = (
         return packageManager;
       }
 
+      if (existsSync(resolve(dir, BUN_LOCK))) {
+        localCache.set(key, "bun");
+
+        return "bun";
+      }
+
       if (existsSync(resolve(dir, NPM_LOCK))) {
         localCache.set(key, "npm");
 
@@ -127,6 +140,8 @@ export const detectPackageManager = (
       ? "pnpm"
       : hasGlobalInstallation("yarn")
       ? "yarn"
+      : hasGlobalInstallation("bun")
+      ? "bun"
       : "npm")
   );
 };

--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -13,6 +13,19 @@ export const getRegistry = (packageManager: PackageManager): string => {
       `${packageManager} config get npmRegistryServer`
     ).stdout.replace(/\/?$/, "/");
 
+  if (
+    packageManager === "bun" &&
+    !execaCommandSync(`${packageManager} --version`).exitCode
+  ) {
+    console.warn(
+      "bun does not support get registry at the time, using npm global registry instead"
+    );
+    return execaCommandSync(
+      // TODO: wait for bun to support get registry config
+      `npm config get registry`
+    ).stdout.replace(/\/?$/, "/");
+  }
+
   return execaCommandSync(
     `${packageManager} config get registry`
   ).stdout.replace(/\/?$/, "/");
@@ -30,6 +43,8 @@ export const checkTaobaoRegistry = (packageManager: PackageManager): void => {
       execaCommandSync(
         `${packageManager} config set npmRegistryServer  ${NPM_MIRROR_REGISTRY}`
       );
+    } else if (packageManager === "bun") {
+      execaCommandSync(`npm config set registry ${NPM_MIRROR_REGISTRY}`);
     } else {
       execaCommandSync(
         `${packageManager} config set registry ${NPM_MIRROR_REGISTRY}`


### PR DESCRIPTION
This pull request adds partial support for the bun package manager. It includes changes to the CLI command usage and the detection of the bun lock file. Additionally, it adds the bun package manager as an option for the `detectPackageManager` function. This allows users to use bun as their package manager when updating VuePress projects. The pull request also includes some hacky implementation to the `getRegistry` and `checkTaobaoRegistry` functions given that bun does not support getting or setting config at the time.